### PR TITLE
add powercord manifest

### DIFF
--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "DiscordNight",
+  "description": "Dark and compact theme for BetterDiscord and Powercord",
+  "version": "0.9.1",
+  "author": "KillYoy#0295",
+  "theme": "DiscordNight.theme.css",
+  "license": ""
+}


### PR DESCRIPTION
Adds a Powercord manifest file for use with Powercord. The theme works fine on Powercord since it's the same CSS.