### PR TITLE
Fully remove role circle

### DIFF
--- a/DiscordNight.css
+++ b/DiscordNight.css
@@ -7687,7 +7687,7 @@ body {
 }
 /* Role Remove Button */
 .role-2irmRk .roleCircle-3xAZ1j {
-	width: 0px;
+	width: 0px !important;
 }
 .userPopout-xaxa6l .rolesList-1geHY1:hover .roleCircle-3xAZ1j,
 .customScroller-26gWhv .card-FDVird:hover .role-2irmRk .roleCircle-3xAZ1j {


### PR DESCRIPTION
I'm unsure if this is intentional, but when hovering over the role circle it becomes visible.
I fixed this by adding the !important tag, I have not seen any side-effects to this but I may have missed them.