### PR TITLE
Moddable Padding, for people who want Uniformity

### DIFF
--- a/DiscordNight.css
+++ b/DiscordNight.css
@@ -22,6 +22,8 @@
 	--Channel-List-Upcoming-Events: flex;				/* flex = ON, none = OFF */
 	--Channel-List-Boost-Goal: block;					/* block = ON, none = OFF */
 	--Channel-List-Width: 200px;						/* 200px, Discord default = 240px */
+	--Channel-List-Padding: 0px;						/* 0px, Discord default = 4px */
+	--Channel-List-Padding-Left: 0px;						/* 0px, Discord default = 4px */
 	
 	--User-List-Width: 200px;							/* 200px, Discord default = 240px */
 	--User-Popout-Width: 236px;							/* 236px, Discord default = 300px */
@@ -599,7 +601,8 @@
 /* Channels Placement/Formatting */
 .sidebar-1tnWFu [class^='scroller'] [class^='content'] {
 	margin: 0px;
-	padding: 0px;
+	padding: var(--Channel-List-Padding);
+	padding-left: var(--Channel-List-Padding-Left);
 }
 .sidebar-1tnWFu [class^='scroller'] {
 	margin-right: -8px;


### PR DESCRIPTION
The Current Theme does not expose the Channel page padding to match the uniformity with the rest of the Theme; But thats ok, This also fixes https://github.com/KillYoy/DiscordNight/issues/43 where things are cut off, you can add this to your file and add like 4px of padding to prevent the issue from happening.  Given they would need to do it, but its a fix nevertheless while also allowing people to not see any differences unless they make edits.

Love the Theme!