### PR TITLE
Correct system settings icon for Linux

### DIFF
--- a/DiscordNight.css
+++ b/DiscordNight.css
@@ -8359,6 +8359,7 @@ tooltipBrand__68214 .tooltipPointer_f7411c {
 	transform: scale(0.81);
 }
 /* Linux Settings */
+.standardSidebarView__12528 [aria-label="User Settings"].side_b4b3f6 .item__48dda:nth-child(27)::before,
 .standardSidebarView__12528 .side_b4b3f6 .item__48dda[aria-controls="linux-tab" i]::before {
 	background: url("https://raw.githubusercontent.com/KillYoy/DiscordNight/master/Icons/SVG/Diamond.svg");
 }


### PR DESCRIPTION
Now we Linux users don'thave to look at this:
![image](https://github.com/KillYoy/DiscordNight/assets/149788479/925e26fd-7ed4-4997-a795-9e2cf609bbc7)

But why a diamond? (
![image](https://github.com/KillYoy/DiscordNight/assets/149788479/6430c4cd-b683-479e-9f21-cdf570b1ae84)
)
Why not tux?
![Linux](https://github.com/KillYoy/DiscordNight/assets/149788479/3546a104-44e8-4d3b-ac84-45dc57c83e45)
[ps there's a tux up there ^ (https://github.com/KillYoy/DiscordNight/assets/149788479/3546a104-44e8-4d3b-ac84-45dc57c83e45)]
